### PR TITLE
Simple div extension

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -55,7 +55,7 @@ module.exports = async function execute(code, config) {
       var fn = config.ext[parsed.fnName]
 
       if (typeof fn == 'function') {
-        var nonFuncExt = ['if', 'then', 'else', 'return', 'delete']
+        var nonFuncExt = ['if', 'then', 'else', 'return', 'delete', 'div']
 
         if (!nonFuncExt.includes(parsed.fnName)) {
           val = await func.executeFn({ ...args, parsed, val, fn })

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,0 +1,26 @@
+var parser = require('himalaya')
+
+var html = { ext: {} }
+
+html.ext.div = function ({ get, set, current }) {
+  var result = []
+  var input = get(current)
+
+  if (typeof input == 'string') {
+    result = [
+      {
+        type: 'element',
+        tagName: 'div',
+        children: [{ type: 'text', content: input }]
+      }
+    ]
+  } else {
+    // Possible approach on future task
+    // var htmlContent = `<div>${input}</div>`
+    // var contentParsed = parser.parse(htmlContent)
+  }
+
+  set('tags', result)
+}
+
+module.exports = html

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,8 +1,8 @@
 var parser = require('himalaya')
 
-var html = { ext: {} }
+var html = {}
 
-html.ext.div = function ({ get, set, current }) {
+html.div = function ({ get, set, current }) {
   var result = []
   var input = get(current)
 
@@ -14,10 +14,6 @@ html.ext.div = function ({ get, set, current }) {
         children: [{ type: 'text', content: input }]
       }
     ]
-  } else {
-    // Possible approach on future task
-    // var htmlContent = `<div>${input}</div>`
-    // var contentParsed = parser.parse(htmlContent)
   }
 
   set('tags', result)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "d8a": "^0.10.2",
         "extras": "^0.17.0",
+        "himalaya": "^1.1.1",
         "js-yaml": "github:eldoy/js-yaml",
         "lodash": "^4.17.21"
       },
@@ -106,6 +107,12 @@
         "lodash": "^4.17.21",
         "uuid": "^10.0.0"
       }
+    },
+    "node_modules/himalaya": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/himalaya/-/himalaya-1.1.1.tgz",
+      "integrity": "sha512-mJLY5tErGWtsw8hO2fJ2vK4IpG6S1AIgVkduRo4FqFJhgI2H3XLzgemRemk45zcnFyxNNpOfrIDle2KcnJM0lA==",
+      "license": "ISC"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -242,6 +249,11 @@
         "lodash": "^4.17.21",
         "uuid": "^10.0.0"
       }
+    },
+    "himalaya": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/himalaya/-/himalaya-1.1.1.tgz",
+      "integrity": "sha512-mJLY5tErGWtsw8hO2fJ2vK4IpG6S1AIgVkduRo4FqFJhgI2H3XLzgemRemk45zcnFyxNNpOfrIDle2KcnJM0lA=="
     },
     "js-yaml": {
       "version": "git+ssh://git@github.com/eldoy/js-yaml.git#d58b34c29830ae7fd1207fa1adde2666fceab6d6",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "d8a": "^0.10.2",
     "extras": "^0.17.0",
+    "himalaya": "^1.1.1",
     "js-yaml": "github:eldoy/js-yaml",
     "lodash": "^4.17.21"
   }

--- a/spec/lib/ext.js
+++ b/spec/lib/ext.js
@@ -1,5 +1,3 @@
-var { parse } = require('himalaya')
-
 var ext = {}
 
 ext.db = function ({ set }) {
@@ -20,17 +18,6 @@ ext.sum = function ({ get, current }) {
 
 ext.log = function ({ get, current }) {
   console.log(get(current))
-}
-
-ext.div = function ({ get, set, current }) {
-  var content = ''
-  var input = get(current)
-
-  if (typeof input === 'string') content = input
-  var htmlContent = `<div>${content}</div>`
-
-  var contentParsed = parse(htmlContent)
-  set('tags', contentParsed)
 }
 
 module.exports = ext

--- a/spec/lib/ext.js
+++ b/spec/lib/ext.js
@@ -1,3 +1,5 @@
+var { parse } = require('himalaya')
+
 var ext = {}
 
 ext.db = function ({ set }) {
@@ -18,6 +20,17 @@ ext.sum = function ({ get, current }) {
 
 ext.log = function ({ get, current }) {
   console.log(get(current))
+}
+
+ext.div = function ({ get, set, current }) {
+  var content = ''
+  var input = get(current)
+
+  if (typeof input === 'string') content = input
+  var htmlContent = `<div>${content}</div>`
+
+  var contentParsed = parse(htmlContent)
+  set('tags', contentParsed)
 }
 
 module.exports = ext

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -1,0 +1,25 @@
+var weblang = require('../../index.js')
+var { div } = require('../lib/ext.js')
+
+test('simple div', async ({ t }) => {
+  var expectedTags = [
+    {
+      type: 'element',
+      tagName: 'div',
+      attributes: [],
+      children: [{ type: 'text', content: 'hello' }]
+    }
+  ]
+
+  // String content
+  var code = ['@div:', ' hello'].join('\n')
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.deepEqual(state, { vars: { tags: expectedTags } })
+
+  // Variable content
+  var code = ['=myVar: hello', '@div:', ' $myVar'].join('\n')
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.deepEqual(state, { vars: { myVar: 'hello', tags: expectedTags } })
+})

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -1,25 +1,14 @@
 var weblang = require('../../index.js')
-var { div } = require('../lib/ext.js')
+var { ext } = require('../../lib/html.js')
 
 test('simple div', async ({ t }) => {
-  var expectedTags = [
-    {
-      type: 'element',
-      tagName: 'div',
-      attributes: [],
-      children: [{ type: 'text', content: 'hello' }]
-    }
-  ]
-
   // String content
-  var code = ['@div:', ' hello'].join('\n')
-  var state = await weblang.init({ ext: { div } }).run(code)
+  var code = '@div: hello'
+  var state = await weblang.init({ ext: { div: ext.div } }).run(code)
 
-  t.deepEqual(state, { vars: { tags: expectedTags } })
-
-  // Variable content
-  var code = ['=myVar: hello', '@div:', ' $myVar'].join('\n')
-  var state = await weblang.init({ ext: { div } }).run(code)
-
-  t.deepEqual(state, { vars: { myVar: 'hello', tags: expectedTags } })
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'hello')
 })

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -1,10 +1,10 @@
 var weblang = require('../../index.js')
-var { ext } = require('../../lib/html.js')
+var { div } = require('../../lib/html.js')
 
 test('simple div', async ({ t }) => {
   // String content
   var code = '@div: hello'
-  var state = await weblang.init({ ext: { div: ext.div } }).run(code)
+  var state = await weblang.init({ ext: { div } }).run(code)
 
   t.equal(state.vars.tags[0].type, 'element')
   t.equal(state.vars.tags[0].tagName, 'div')


### PR DESCRIPTION
## 📌 Add `div ext` to generate div html tags.

### 🔍 Description
This PR adds a **@div** extension on `spec/lib/ext` folder to:
- Get the current content inserted on the @div.
- If the content is a string, assign that current content to a new **div tag**.
- Parse that **div tag** with Himalaya and save it on **state.vars.tags**.

---

### 🧪 Test 
Adds 2 cases on `simple div` suit using **deepEqual**:
- Simple string on content: **@div: hello**
- Simple string var on content: **@div: $someVar**

