### PR TITLE
Process sibling tags and tags with attrs

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -3,45 +3,33 @@ var parser = require('himalaya')
 var html = {}
 
 html.div = function ({ get, set, current }) {
-  var result = []
-  var input = get(current)
-
-  if (typeof input == 'string') {
-    result = [
-      {
-        type: 'element',
-        tagName: 'div',
-        attributes: [],
-        children: [{ type: 'text', content: input }]
-      }
-    ]
-  } else {
-    var content = input?.text ?? ''
-    var attributes = []
-
-    for (var [key, rawValue] of Object.entries(input)) {
-      if (key === 'text' || key.startsWith('@') || key.startsWith('=')) {
-        continue
-      }
-
-      var resolvedValue = get(rawValue)
-      var hasValue = resolvedValue !== undefined && resolvedValue !== null
-
-      if (hasValue) attributes.push({ key, value: resolvedValue })
-    }
-
-    result = [
-      {
-        type: 'element',
-        tagName: 'div',
-        attributes,
-        children: [{ type: 'text', content }]
-      }
-    ]
+  var tags = get('$tags') || []
+  var element = {
+    type: 'element',
+    tagName: 'div',
+    attributes: [],
+    children: []
   }
 
-  var tags = get('$tags') ?? []
-  set('tags', [...tags, ...result])
+  var content = ''
+  if (typeof current == 'string') {
+    content = current
+  } else {
+    for (var key in current) {
+      if (key == 'text') {
+        content = current[key]
+      } else {
+        element.attributes.push({ key, value: current[key] })
+      }
+    }
+  }
+
+  if (content) {
+    element.children.push({ type: 'text', content })
+  }
+
+  tags.push(element)
+  set('tags', tags)
 }
 
 module.exports = html

--- a/lib/html.js
+++ b/lib/html.js
@@ -2,8 +2,25 @@ var parser = require('himalaya')
 
 var html = {}
 
-html.div = function ({ get, set, current }) {
-  var tags = get('$tags') || []
+html.div = async function ({ get, set, run, val, state, current }) {
+  if (state.vars.level == undefined) {
+    state.vars.level = 0
+  }
+
+  function buildPath(withDollar) {
+    var path = withDollar ? '$tags[0]' : 'tags[0]'
+
+    if (state.vars.level === 0) return withDollar ? '$tags' : 'tags'
+
+    for (var i = 0; i < state.vars.level; i++) {
+      path += i === 0 ? '.children' : '[0].children'
+    }
+
+    return path
+  }
+
+  var tags = get(buildPath(true)) || []
+
   var element = {
     type: 'element',
     tagName: 'div',
@@ -12,12 +29,15 @@ html.div = function ({ get, set, current }) {
   }
 
   var content = ''
+  var hasDivChild = false
   if (typeof current == 'string') {
     content = current
   } else {
     for (var key in current) {
       if (key == 'text') {
         content = current[key]
+      } else if (key.startsWith('@div')) {
+        hasDivChild = true
       } else {
         element.attributes.push({ key, value: current[key] })
       }
@@ -29,7 +49,12 @@ html.div = function ({ get, set, current }) {
   }
 
   tags.push(element)
-  set('tags', tags)
+  set(buildPath(false), tags)
+
+  if (hasDivChild) {
+    state.vars.level++
+    await run(val)
+  }
 }
 
 module.exports = html

--- a/lib/html.js
+++ b/lib/html.js
@@ -11,12 +11,37 @@ html.div = function ({ get, set, current }) {
       {
         type: 'element',
         tagName: 'div',
+        attributes: [],
         children: [{ type: 'text', content: input }]
+      }
+    ]
+  } else {
+    var content = input?.text ?? ''
+    var attributes = []
+
+    for (var [key, rawValue] of Object.entries(input)) {
+      if (key === 'text' || key.startsWith('@') || key.startsWith('=')) {
+        continue
+      }
+
+      var resolvedValue = get(rawValue)
+      var hasValue = resolvedValue !== undefined && resolvedValue !== null
+
+      if (hasValue) attributes.push({ key, value: resolvedValue })
+    }
+
+    result = [
+      {
+        type: 'element',
+        tagName: 'div',
+        attributes,
+        children: [{ type: 'text', content }]
       }
     ]
   }
 
-  set('tags', result)
+  var tags = get('$tags') ?? []
+  set('tags', [...tags, ...result])
 }
 
 module.exports = html

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -48,3 +48,17 @@ test('simple attributes', async ({ t }) => {
   t.equal(state.vars.tags[0].children[0].type, 'text')
   t.equal(state.vars.tags[0].children[0].content, 'bye')
 })
+
+test('simple nested', async ({ t }) => {
+  var code = ['@div:', ' @div: hello'].join('\n')
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'element')
+  t.equal(state.vars.tags[0].children[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].children[0].content, 'hello')
+})

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -2,7 +2,6 @@ var weblang = require('../../index.js')
 var { div } = require('../../lib/html.js')
 
 test('simple div', async ({ t }) => {
-  // String content
   var code = '@div: hello'
   var state = await weblang.init({ ext: { div } }).run(code)
 
@@ -11,4 +10,41 @@ test('simple div', async ({ t }) => {
   t.equal(state.vars.tags[0].children.length, 1)
   t.equal(state.vars.tags[0].children[0].type, 'text')
   t.equal(state.vars.tags[0].children[0].content, 'hello')
+})
+
+test('multi div', async ({ t }) => {
+  var code = ['@div: hello', '@div: bye'].join('\n')
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.tags.length, 2)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'hello')
+
+  t.equal(state.vars.tags[1].type, 'element')
+  t.equal(state.vars.tags[1].tagName, 'div')
+  t.equal(state.vars.tags[1].children.length, 1)
+  t.equal(state.vars.tags[1].children[0].type, 'text')
+  t.equal(state.vars.tags[1].children[0].content, 'bye')
+})
+
+test('simple attributes', async ({ t }) => {
+  var code = '@div: { id: 123, class: hello, text: bye }'
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+
+  t.equal(state.vars.tags[0].attributes.length, 2)
+  t.equal(state.vars.tags[0].attributes[0].key, 'id')
+  t.equal(state.vars.tags[0].attributes[0].value, '123')
+  t.equal(state.vars.tags[0].attributes[1].key, 'class')
+  t.equal(state.vars.tags[0].attributes[1].value, 'hello')
+
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'bye')
 })


### PR DESCRIPTION
# Add support for div with attributes & sibling nodes

### ✅ What’s new

- Accepts objects with attributes + text:  
  `{ id: 1, class: "box", text: "Hello" }`
- Skips keys like `@...`, `=...`, or `text` when collecting attributes.
- Appends result to `$tags` concatenating with previous tags if any (sibling nodes).

### 🧪 Tests added

- **multi div**: confirms two `@div:` entries create two elements.
- **simple attributes**: checks that attributes are parsed and stored correctly.
