### PR TITLE
Add variable values on div and refactor ext

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -33,7 +33,11 @@ html.div = async function ({ get, set, run, val, state, current }) {
 
   var content = ''
   var hasChild = false
-  if (typeof current == 'string') {
+  if (
+    typeof current == 'string' ||
+    typeof current == 'number' ||
+    typeof current == 'boolean'
+  ) {
     content = current
   } else {
     for (var key in current) {

--- a/lib/html.js
+++ b/lib/html.js
@@ -3,12 +3,12 @@ var parser = require('himalaya')
 var html = {}
 
 html.div = async function ({ get, set, run, val, state, current }) {
-  state.vars.currentLevel = state.vars.currentLevel || 0
-  state.vars.previousLevel = state.vars.previousLevel || 0
+  state.vars.currentLevel ||= 0
+  state.vars.previousLevel ||= 0
 
   var tagsPath = 'tags'
 
-  if (state.vars.currentLevel !== 0) {
+  if (state.vars.currentLevel > 0) {
     var path = 'tags[0]'
 
     for (var i = 0; i < state.vars.currentLevel; i++) {

--- a/lib/html.js
+++ b/lib/html.js
@@ -38,11 +38,11 @@ html.div = async function ({ get, set, run, val, state, current }) {
     typeof current == 'number' ||
     typeof current == 'boolean'
   ) {
-    content = current
+    content = get(current)
   } else {
     for (var key in current) {
       if (key == 'text') {
-        content = current[key]
+        content = get(current[key])
       } else if (key.startsWith('@div')) {
         hasChild = true
       } else {

--- a/lib/html.js
+++ b/lib/html.js
@@ -3,26 +3,22 @@ var parser = require('himalaya')
 var html = {}
 
 html.div = async function ({ get, set, run, val, state, current }) {
-  if (state.vars.currentLevel == null) {
-    state.vars.currentLevel = 0
-  }
-  if (state.vars.previousLevel == null) {
-    state.vars.previousLevel = 0
-  }
+  state.vars.currentLevel = state.vars.currentLevel || 0
+  state.vars.previousLevel = state.vars.previousLevel || 0
 
-  function buildPath() {
+  var tagsPath = 'tags'
+
+  if (state.vars.currentLevel !== 0) {
     var path = 'tags[0]'
-
-    if (state.vars.currentLevel === 0) return 'tags'
 
     for (var i = 0; i < state.vars.currentLevel; i++) {
       path += i === 0 ? '.children' : '[0].children'
     }
 
-    return path
+    tagsPath = path
   }
 
-  var tags = get('$' + buildPath()) || []
+  var tags = get('$' + tagsPath) || []
 
   var element = {
     type: 'element',
@@ -33,11 +29,7 @@ html.div = async function ({ get, set, run, val, state, current }) {
 
   var content = ''
   var hasChild = false
-  if (
-    typeof current == 'string' ||
-    typeof current == 'number' ||
-    typeof current == 'boolean'
-  ) {
+  if (['string', 'number', 'boolean'].includes(typeof current)) {
     content = get(current)
   } else {
     for (var key in current) {
@@ -56,7 +48,7 @@ html.div = async function ({ get, set, run, val, state, current }) {
   }
 
   tags.push(element)
-  set(buildPath(), tags)
+  set(tagsPath, tags)
 
   if (hasChild) {
     state.vars.previousLevel = state.vars.currentLevel

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -133,3 +133,36 @@ test('variable text value', async ({ t }) => {
   t.equal(state.vars.tags[0].children[0].type, 'text')
   t.equal(state.vars.tags[0].children[0].content, 'world')
 })
+
+test('nested with attributes', async ({ t }) => {
+  var code = [
+    '@div:',
+    ' class: a',
+    ' text: hello',
+    ' @div:',
+    '  class: a',
+    '  text: bye'
+  ].join('\n')
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.previousLevel, 0)
+  t.equal(state.vars.currentLevel, 1)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children.length, 2)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'hello')
+  t.equal(state.vars.tags[0].attributes.length, 1)
+  t.equal(state.vars.tags[0].attributes[0].key, 'class')
+  t.equal(state.vars.tags[0].attributes[0].value, 'a')
+
+  t.equal(state.vars.tags[0].children[1].type, 'element')
+  t.equal(state.vars.tags[0].children[1].tagName, 'div')
+  t.equal(state.vars.tags[0].children[1].children.length, 1)
+  t.equal(state.vars.tags[0].children[1].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[1].children[0].content, 'bye')
+  t.equal(state.vars.tags[0].children[1].attributes.length, 1)
+  t.equal(state.vars.tags[0].children[1].attributes[0].key, 'class')
+  t.equal(state.vars.tags[0].children[1].attributes[0].value, 'a')
+})

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -65,3 +65,47 @@ test('simple nested', async ({ t }) => {
   t.equal(state.vars.tags[0].children[0].children[0].type, 'text')
   t.equal(state.vars.tags[0].children[0].children[0].content, 'hello')
 })
+
+test('empty object', async ({ t }) => {
+  var code = '@div: {}'
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].attributes.length, 0)
+  t.equal(state.vars.tags[0].children.length, 0)
+})
+
+test('null value', async ({ t }) => {
+  var code = '@div: null'
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].attributes.length, 0)
+  t.equal(state.vars.tags[0].children.length, 0)
+})
+
+test('number value', async ({ t }) => {
+  var code = '@div: 5'
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].attributes.length, 0)
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 5)
+})
+
+test('boolean value', async ({ t }) => {
+  var code = '@div: true'
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].attributes.length, 0)
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, true)
+})

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -109,3 +109,27 @@ test('boolean value', async ({ t }) => {
   t.equal(state.vars.tags[0].children[0].type, 'text')
   t.equal(state.vars.tags[0].children[0].content, true)
 })
+
+test('variable value', async ({ t }) => {
+  var code = ['=hello: world', '@div: $hello'].join('\n')
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].attributes.length, 0)
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'world')
+})
+
+test('variable text value', async ({ t }) => {
+  var code = ['=hello: world', '@div:', ' text: $hello'].join('\n')
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].attributes.length, 0)
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'world')
+})


### PR DESCRIPTION
## Allow variable values on refactored div extension

- Allow divs to get text content from `$variable` syntax
- Refactor div extension, replace `buildPath()` function with simple variable
- Add test cases for different values on text
- Add test case for text and attrs on nested div