### PR TITLE
Allow different @tags on html.js 

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -1,6 +1,7 @@
 var compile = require('./compile.js')
 var parse = require('./parse.js')
 var expand = require('./expand.js')
+var html = require('./html.js')
 var func = require('./func.js')
 var get = require('./get.js')
 var set = require('./set.js')
@@ -33,6 +34,7 @@ module.exports = async function execute(code, config) {
         node,
         current,
         key,
+        ext,
         id,
         run,
         config,
@@ -55,7 +57,8 @@ module.exports = async function execute(code, config) {
       var fn = config.ext[parsed.fnName]
 
       if (typeof fn == 'function') {
-        var nonFuncExt = ['if', 'then', 'else', 'return', 'delete', 'div']
+        var tagsExt = Object.keys(html)
+        var nonFuncExt = ['if', 'then', 'else', 'return', 'delete', ...tagsExt]
 
         if (!nonFuncExt.includes(parsed.fnName)) {
           val = await func.executeFn({ ...args, parsed, val, fn })

--- a/lib/html.js
+++ b/lib/html.js
@@ -2,7 +2,7 @@ var parser = require('himalaya')
 
 var html = {}
 
-html.div = async function ({ get, set, run, val, state, current }) {
+async function simpleTag({ get, set, run, val, ext, state, current }) {
   state.vars.currentLevel ||= 0
   state.vars.previousLevel ||= 0
 
@@ -22,7 +22,7 @@ html.div = async function ({ get, set, run, val, state, current }) {
 
   var element = {
     type: 'element',
-    tagName: 'div',
+    tagName: ext,
     attributes: [],
     children: []
   }
@@ -35,7 +35,7 @@ html.div = async function ({ get, set, run, val, state, current }) {
     for (var key in current) {
       if (key == 'text') {
         content = get(current[key])
-      } else if (key.startsWith('@div')) {
+      } else if (key.startsWith('@')) {
         hasChild = true
       } else {
         element.attributes.push({ key, value: current[key] })
@@ -56,5 +56,8 @@ html.div = async function ({ get, set, run, val, state, current }) {
     await run(val)
   }
 }
+
+html.div = simpleTag
+html.p = simpleTag
 
 module.exports = html

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -203,3 +203,37 @@ test('simple paragraph', async ({ t }) => {
   t.equal(state.vars.tags[0].children[0].type, 'text')
   t.equal(state.vars.tags[0].children[0].content, 'hello')
 })
+
+test('simple div, paragraph', async ({ t }) => {
+  var code = ['@div: hello', '@p: bye'].join('\n')
+  var state = await weblang.init({ ext: { div, p } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'hello')
+
+  t.equal(state.vars.tags[1].type, 'element')
+  t.equal(state.vars.tags[1].tagName, 'p')
+  t.equal(state.vars.tags[1].children.length, 1)
+  t.equal(state.vars.tags[1].children[0].type, 'text')
+  t.equal(state.vars.tags[1].children[0].content, 'bye')
+})
+
+test('nested div, paragraph', async ({ t }) => {
+  var code = ['@div:', ' text: hello', ' @p: bye'].join('\n')
+  var state = await weblang.init({ ext: { div, p } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children.length, 2)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'hello')
+
+  t.equal(state.vars.tags[0].children[1].type, 'element')
+  t.equal(state.vars.tags[0].children[1].tagName, 'p')
+  t.equal(state.vars.tags[0].children[1].children.length, 1)
+  t.equal(state.vars.tags[0].children[1].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[1].children[0].content, 'bye')
+})

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -1,5 +1,5 @@
 var weblang = require('../../index.js')
-var { div } = require('../../lib/html.js')
+var { div, p } = require('../../lib/html.js')
 
 test('simple div', async ({ t }) => {
   var code = '@div: hello'
@@ -191,4 +191,15 @@ test('nested obj with attributes', async ({ t }) => {
   t.equal(state.vars.tags[0].children[1].attributes.length, 1)
   t.equal(state.vars.tags[0].children[1].attributes[0].key, 'class')
   t.equal(state.vars.tags[0].children[1].attributes[0].value, 'a')
+})
+
+test('simple paragraph', async ({ t }) => {
+  var code = '@p: hello'
+  var state = await weblang.init({ ext: { p } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'p')
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'hello')
 })

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -166,3 +166,29 @@ test('nested with attributes', async ({ t }) => {
   t.equal(state.vars.tags[0].children[1].attributes[0].key, 'class')
   t.equal(state.vars.tags[0].children[1].attributes[0].value, 'a')
 })
+
+test('nested obj with attributes', async ({ t }) => {
+  var code = '@div: { class: a, text: hello, @div: { class: a, text: bye }  }'
+  var state = await weblang.init({ ext: { div } }).run(code)
+
+  t.equal(state.vars.previousLevel, 0)
+  t.equal(state.vars.currentLevel, 1)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children.length, 2)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'hello')
+  t.equal(state.vars.tags[0].attributes.length, 1)
+  t.equal(state.vars.tags[0].attributes[0].key, 'class')
+  t.equal(state.vars.tags[0].attributes[0].value, 'a')
+
+  t.equal(state.vars.tags[0].children[1].type, 'element')
+  t.equal(state.vars.tags[0].children[1].tagName, 'div')
+  t.equal(state.vars.tags[0].children[1].children.length, 1)
+  t.equal(state.vars.tags[0].children[1].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[1].children[0].content, 'bye')
+  t.equal(state.vars.tags[0].children[1].attributes.length, 1)
+  t.equal(state.vars.tags[0].children[1].attributes[0].key, 'class')
+  t.equal(state.vars.tags[0].children[1].attributes[0].value, 'a')
+})


### PR DESCRIPTION
Allow different tags after @, add more test cases

- Make tags on `html.js` extensible (not only for @div)
- Add @p tag on `html.js` and test cases for it