### PR TITLE
Change process on simple tag extensions

### DIFF
--- a/lib/execute.js
+++ b/lib/execute.js
@@ -12,7 +12,6 @@ module.exports = async function execute(code, config) {
   var tree = compile(code)
 
   var state = { vars: {} }
-  var tagLevels = []
 
   // Add custom vars
   if (config.vars) {
@@ -28,7 +27,6 @@ module.exports = async function execute(code, config) {
       var [key, ext, id] = parse(node)
       var current = branch[node]
       var args = {
-        tagLevels,
         state,
         code,
         tree,

--- a/lib/execute.js
+++ b/lib/execute.js
@@ -12,6 +12,7 @@ module.exports = async function execute(code, config) {
   var tree = compile(code)
 
   var state = { vars: {} }
+  var tagLevels = []
 
   // Add custom vars
   if (config.vars) {
@@ -20,13 +21,14 @@ module.exports = async function execute(code, config) {
     }
   }
 
-  async function run(branch) {
+  async function run(branch, currentLevel) {
     for (var node in branch) {
       if (typeof state.return != 'undefined') break
 
       var [key, ext, id] = parse(node)
       var current = branch[node]
       var args = {
+        tagLevels,
         state,
         code,
         tree,
@@ -63,7 +65,7 @@ module.exports = async function execute(code, config) {
         if (!nonFuncExt.includes(parsed.fnName)) {
           val = await func.executeFn({ ...args, parsed, val, fn })
         } else {
-          val = await fn({ ...args, val })
+          val = await fn({ ...args, val, currentLevel })
         }
       }
 
@@ -73,7 +75,8 @@ module.exports = async function execute(code, config) {
     }
   }
 
-  await run(tree)
+  // Start running tree at level 0
+  await run(tree, 0)
 
   return state
 }

--- a/lib/html.js
+++ b/lib/html.js
@@ -2,17 +2,42 @@ var parser = require('himalaya')
 
 var html = {}
 
-async function simpleTag({ get, set, run, val, ext, state, current }) {
-  state.vars.currentLevel ||= 0
-  state.vars.previousLevel ||= 0
+async function simpleTag({
+  get,
+  set,
+  run,
+  val,
+  ext,
+  currentLevel,
+  tagLevels,
+  current
+}) {
+  var previousLevel = tagLevels[tagLevels.length - 1]
+  var siblingIndex = 0
+
+  for (var i = tagLevels.length - 1; i >= 0; i--) {
+    var level = tagLevels[i]
+    if (level === previousLevel) {
+      siblingIndex++
+    } else if (level < previousLevel) {
+      break
+    }
+  }
+
+  tagLevels.push(currentLevel)
 
   var tagsPath = 'tags'
-
-  if (state.vars.currentLevel > 0) {
+  if (currentLevel > 0) {
     var path = 'tags[0]'
 
-    for (var i = 0; i < state.vars.currentLevel; i++) {
-      path += i === 0 ? '.children' : '[0].children'
+    for (var i = 0; i < currentLevel; i++) {
+      if (i === 0) {
+        path += '.children'
+      } else if (i === currentLevel - 1) {
+        path += `[${siblingIndex - 1}].children`
+      } else {
+        path += '[0].children'
+      }
     }
 
     tagsPath = path
@@ -51,9 +76,7 @@ async function simpleTag({ get, set, run, val, ext, state, current }) {
   set(tagsPath, tags)
 
   if (hasChild) {
-    state.vars.previousLevel = state.vars.currentLevel
-    state.vars.currentLevel++
-    await run(val)
+    await run(val, currentLevel + 1)
   }
 }
 

--- a/lib/html.js
+++ b/lib/html.js
@@ -24,11 +24,19 @@ async function simpleTag({
     }
   }
 
+  var parentTagLevel = 0
+  for (var i = 0; i <= tagLevels.length - 1; i++) {
+    var level = tagLevels[i]
+    if (level === 0) {
+      parentTagLevel++
+    }
+  }
+
   tagLevels.push(currentLevel)
 
   var tagsPath = 'tags'
   if (currentLevel > 0) {
-    var path = 'tags[0]'
+    var path = `tags[${parentTagLevel < 0 ? 0 : parentTagLevel - 1}]`
 
     for (var i = 0; i < currentLevel; i++) {
       if (i === 0) {

--- a/lib/html.js
+++ b/lib/html.js
@@ -2,56 +2,18 @@ var parser = require('himalaya')
 
 var html = {}
 
-async function simpleTag({
-  get,
-  set,
-  run,
-  val,
-  ext,
-  currentLevel,
-  tagLevels,
-  current
-}) {
-  var previousLevel = tagLevels[tagLevels.length - 1]
-  var siblingIndex = 0
+async function simpleTag({ get, set, run, val, ext, currentLevel, current }) {
+  var levelPathMap = get('$levelPathMap') || []
+  var parentPath = currentLevel > 0 ? levelPathMap[currentLevel - 1] : null
+  var newElementPath
 
-  for (var i = tagLevels.length - 1; i >= 0; i--) {
-    var level = tagLevels[i]
-    if (level === previousLevel) {
-      siblingIndex++
-    } else if (level < previousLevel) {
-      break
-    }
+  if (parentPath) {
+    var siblings = get('$' + parentPath + '.children') || []
+    newElementPath = `${parentPath}.children[${siblings.length}]`
+  } else {
+    var rootTags = get('$tags') || []
+    newElementPath = `tags[${rootTags.length}]`
   }
-
-  var parentTagLevel = 0
-  for (var i = 0; i <= tagLevels.length - 1; i++) {
-    var level = tagLevels[i]
-    if (level === 0) {
-      parentTagLevel++
-    }
-  }
-
-  tagLevels.push(currentLevel)
-
-  var tagsPath = 'tags'
-  if (currentLevel > 0) {
-    var path = `tags[${parentTagLevel < 0 ? 0 : parentTagLevel - 1}]`
-
-    for (var i = 0; i < currentLevel; i++) {
-      if (i === 0) {
-        path += '.children'
-      } else if (i === currentLevel - 1) {
-        path += `[${siblingIndex - 1}].children`
-      } else {
-        path += '[0].children'
-      }
-    }
-
-    tagsPath = path
-  }
-
-  var tags = get('$' + tagsPath) || []
 
   var element = {
     type: 'element',
@@ -60,14 +22,18 @@ async function simpleTag({
     children: []
   }
 
-  var content = ''
   var hasChild = false
-  if (['string', 'number', 'boolean'].includes(typeof current)) {
-    content = get(current)
-  } else {
+
+  if (
+    typeof current === 'string' ||
+    typeof current === 'number' ||
+    typeof current === 'boolean'
+  ) {
+    element.children.push({ type: 'text', content: get(current) })
+  } else if (current && typeof current === 'object') {
     for (var key in current) {
-      if (key == 'text') {
-        content = get(current[key])
+      if (key === 'text') {
+        element.children.push({ type: 'text', content: get(current[key]) })
       } else if (key.startsWith('@')) {
         hasChild = true
       } else {
@@ -76,16 +42,12 @@ async function simpleTag({
     }
   }
 
-  if (content) {
-    element.children.push({ type: 'text', content })
-  }
+  set(newElementPath, element)
+  levelPathMap[currentLevel] = newElementPath
+  levelPathMap.length = currentLevel + 1
+  set('levelPathMap', levelPathMap)
 
-  tags.push(element)
-  set(tagsPath, tags)
-
-  if (hasChild) {
-    await run(val, currentLevel + 1)
-  }
+  if (hasChild) await run(val, currentLevel + 1)
 }
 
 html.div = simpleTag

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -284,3 +284,43 @@ test('deep nested siblings', async ({ t }) => {
   t.equal(state.vars.tags[0].children[1].children[0].children[0].type, 'text')
   t.equal(state.vars.tags[0].children[1].children[0].children[0].content, 'bye')
 })
+
+test('mixed nested siblings', async ({ t }) => {
+  // prettier-ignore
+  var code = [
+    '@div: hello', 
+    '@div:', 
+    ' @p: whats up', 
+    '@div:', 
+    ' @div:', 
+    '  @p: bye'
+  ].join('\n')
+  var state = await weblang.init({ ext: { div, p } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].content, 'hello')
+
+  t.equal(state.vars.tags[1].type, 'element')
+  t.equal(state.vars.tags[1].tagName, 'div')
+  t.equal(state.vars.tags[1].children.length, 1)
+  t.equal(state.vars.tags[1].children[0].type, 'element')
+  t.equal(state.vars.tags[1].children[0].tagName, 'p')
+  t.equal(state.vars.tags[1].children[0].children.length, 1)
+  t.equal(state.vars.tags[1].children[0].children[0].type, 'text')
+  t.equal(state.vars.tags[1].children[0].children[0].content, 'whats up')
+
+  t.equal(state.vars.tags[2].type, 'element')
+  t.equal(state.vars.tags[2].tagName, 'div')
+  t.equal(state.vars.tags[2].children.length, 1)
+  t.equal(state.vars.tags[2].children[0].type, 'element')
+  t.equal(state.vars.tags[2].children[0].tagName, 'div')
+  t.equal(state.vars.tags[2].children[0].children.length, 1)
+  t.equal(state.vars.tags[2].children[0].children[0].type, 'element')
+  t.equal(state.vars.tags[2].children[0].children[0].tagName, 'p')
+  t.equal(state.vars.tags[2].children[0].children[0].children.length, 1)
+  t.equal(state.vars.tags[2].children[0].children[0].children[0].type, 'text')
+  t.equal(state.vars.tags[2].children[0].children[0].children[0].content, 'bye')
+})

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -237,3 +237,24 @@ test('nested div, paragraph', async ({ t }) => {
   t.equal(state.vars.tags[0].children[1].children[0].type, 'text')
   t.equal(state.vars.tags[0].children[1].children[0].content, 'bye')
 })
+
+test('nested siblings', async ({ t }) => {
+  var code = ['@div:', ' @div: hello', ' @p: bye'].join('\n')
+  var state = await weblang.init({ ext: { div, p } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children.length, 2)
+
+  t.equal(state.vars.tags[0].children[0].type, 'element')
+  t.equal(state.vars.tags[0].children[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[0].children[0].content, 'hello')
+
+  t.equal(state.vars.tags[0].children[1].type, 'element')
+  t.equal(state.vars.tags[0].children[1].tagName, 'p')
+  t.equal(state.vars.tags[0].children[1].children.length, 1)
+  t.equal(state.vars.tags[0].children[1].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[1].children[0].content, 'bye')
+})

--- a/spec/tests/html-test.js
+++ b/spec/tests/html-test.js
@@ -53,9 +53,6 @@ test('simple nested', async ({ t }) => {
   var code = ['@div:', ' @div: hello'].join('\n')
   var state = await weblang.init({ ext: { div } }).run(code)
 
-  t.equal(state.vars.previousLevel, 0)
-  t.equal(state.vars.currentLevel, 1)
-
   t.equal(state.vars.tags[0].type, 'element')
   t.equal(state.vars.tags[0].tagName, 'div')
   t.equal(state.vars.tags[0].children.length, 1)
@@ -145,9 +142,6 @@ test('nested with attributes', async ({ t }) => {
   ].join('\n')
   var state = await weblang.init({ ext: { div } }).run(code)
 
-  t.equal(state.vars.previousLevel, 0)
-  t.equal(state.vars.currentLevel, 1)
-
   t.equal(state.vars.tags[0].type, 'element')
   t.equal(state.vars.tags[0].tagName, 'div')
   t.equal(state.vars.tags[0].children.length, 2)
@@ -170,9 +164,6 @@ test('nested with attributes', async ({ t }) => {
 test('nested obj with attributes', async ({ t }) => {
   var code = '@div: { class: a, text: hello, @div: { class: a, text: bye }  }'
   var state = await weblang.init({ ext: { div } }).run(code)
-
-  t.equal(state.vars.previousLevel, 0)
-  t.equal(state.vars.currentLevel, 1)
 
   t.equal(state.vars.tags[0].type, 'element')
   t.equal(state.vars.tags[0].tagName, 'div')
@@ -257,4 +248,39 @@ test('nested siblings', async ({ t }) => {
   t.equal(state.vars.tags[0].children[1].children.length, 1)
   t.equal(state.vars.tags[0].children[1].children[0].type, 'text')
   t.equal(state.vars.tags[0].children[1].children[0].content, 'bye')
+})
+
+test('deep nested siblings', async ({ t }) => {
+  // prettier-ignore
+  var code = [
+    '@div:', 
+    ' @div:', 
+    '  @p: hello', 
+    ' @div:', 
+    '  @p: bye'
+  ].join('\n')
+  var state = await weblang.init({ ext: { div, p } }).run(code)
+
+  t.equal(state.vars.tags[0].type, 'element')
+  t.equal(state.vars.tags[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children.length, 2)
+
+  t.equal(state.vars.tags[0].children[0].type, 'element')
+  t.equal(state.vars.tags[0].children[0].tagName, 'div')
+  t.equal(state.vars.tags[0].children[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].children[0].type, 'element')
+  t.equal(state.vars.tags[0].children[0].children[0].tagName, 'p')
+  t.equal(state.vars.tags[0].children[0].children[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[0].children[0].children[0].type, 'text')
+  // prettier-ignore
+  t.equal(state.vars.tags[0].children[0].children[0].children[0].content, 'hello')
+
+  t.equal(state.vars.tags[0].children[1].type, 'element')
+  t.equal(state.vars.tags[0].children[1].tagName, 'div')
+  t.equal(state.vars.tags[0].children[1].children.length, 1)
+  t.equal(state.vars.tags[0].children[1].children[0].type, 'element')
+  t.equal(state.vars.tags[0].children[1].children[0].tagName, 'p')
+  t.equal(state.vars.tags[0].children[1].children[0].children.length, 1)
+  t.equal(state.vars.tags[0].children[1].children[0].children[0].type, 'text')
+  t.equal(state.vars.tags[0].children[1].children[0].children[0].content, 'bye')
 })


### PR DESCRIPTION
## Change: Improved Tag Path Logic for Nested & Sibling patterns

### 🧠 Previous Behavior

Previously, when adding nodes to `state.vars.tags`, the path was built with hardcoded indexes like:

- **Level 0:** `tags[0].children`
- **Level 1:** `tags[0].children[0].children`
- **Level 2:** `tags[0].children[0].children[0].children`

This assumed each new node was always the first child (`[0]`). But when siblings exist at different depths, the path should instead reflect actual positions, e.g.:

- `tags[1].children[0].children`
- `tags[0].children[0].children[2].children`

Hardcoding `[0]` failed to support this structure.

---

### ✅ New Behavior

The level is now passed as an **argument** to the recursive `run()` function rather than stored in `state`, avoiding incorrect increments:

```js
if (hasChild) {
  await run(val, currentLevel + 1)
}
```

This ensures each recursive call keeps the correct `level` context.

#### 📊 Tracking Levels & Siblings

We introduced a global `tagLevels` array to store the level of each visited node. This allows dynamic calculation of a node’s sibling index by walking backwards through the array:

```js
for (var i = tagLevels.length - 1; i >= 0; i--) {
  var level = tagLevels[i]
  if (level === previousLevel) {
    siblingIndex++
  } else if (level < previousLevel) {
    break
  }
}
```

Then we build the tag path based on the sibling index:

```js
path += `[${siblingIndex - 1}].children`
```

So if the current node is the 3rd sibling at its level, the resulting path becomes:

```js
tags[0].children[2].children
```

#### 🧮 Handling Top-Level Tags

To count how many top-level (unwrapped) tags exist — that is, nodes at `level === 0` — we iterate through the `tagLevels` array:

```js
var parentTagLevel = 0
  for (var i = 0; i <= tagLevels.length - 1; i++) {
    var level = tagLevels[i]
    if (level === 0) {
      parentTagLevel++
    }
  }
```

This count (parentTagLevel) is used to determine the correct root path. For example, if the current node is the second unwrapped tag, the generated path becomes:

```js
tags[1].children
```

### 🧩 Summary

✅ Removed hardcoded index logic  
✅ Tracks level via recursion argument  
✅ Calculates sibling index dynamically  
✅ Handles top-level tag positioning  

